### PR TITLE
Assert crowdin file ids

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,7 @@ i18n.docs['en-US']['/docs/api/app']
   title: 'app',
   description: '\nControl your application\'s event lifecycle.\n'
   githubUrl: 'https://github.com/electron/electron/tree/master/docs/api/app.md',
+  crowdinFileId: '123',
   isTutorial: false,
   isApiDoc: true,
   isDevTutorial: false,

--- a/test/index.js
+++ b/test/index.js
@@ -184,7 +184,18 @@ describe('API Structures', () => {
     doc.categoryFancy.should.equal('API Structures')
     doc.isApiStructureDoc.should.equal(true)
   })
-  it('Crowdin file ID', () => {
+
+  it('sets crowdinFileId on every doc', () => {
+    const locales = Object.keys(i18n.locales)
+    locales.length.should.be.above(1)
+    locales.forEach(locale => {
+      const docs = Object.keys(i18n.docs[locale]).map(key => i18n.docs[locale][key])
+      docs.length.should.be.above(1)
+      docs.every(doc => doc.crowdinFileId.length).should.equal(true)
+    })
+  })
+
+  it('sets expected crowdinFileId', () => {
     const doc = i18n.docs['fr-FR']['/docs/api/structures/gpu-feature-status']
     doc.crowdinFileId.should.equal('128')
   })


### PR DESCRIPTION
This PR adds an extra test so we can always rely on every doc having a `crowdinFileId` property.

cc @pierreneter @vanessayuenn 