### PR TITLE
chore: replace greenkeeper badge to dependabot badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # electron-i18n
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/electron/i18n.svg)](https://greenkeeper.io/)
+[![Dependabot badge](https://img.shields.io/badge/Dependabot-enabled-blue.svg)](https://dependabot.com/)
 
 > A home for Electron's translated documentation.
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Note: translations should not be submitted as pull requests.

See the README for info on how to participate:

https://github.com/electron/i18n#readme
-->

greenkeeper badge is empty, we now using dependabot.
replace greenkeeper badge to dependabot badge.

![image](https://user-images.githubusercontent.com/14037268/49266805-821ad800-f492-11e8-976a-d1d7b53c5b8e.png)

[![Dependabot badge](https://img.shields.io/badge/Dependabot-enabled-blue.svg)](https://dependabot.com/)