### PR TITLE
fix: change 'menu' class to 'Menu' class

### DIFF
--- a/content/en-US/docs/api/menu.md
+++ b/content/en-US/docs/api/menu.md
@@ -10,7 +10,7 @@ Creates a new menu.
 
 ### Static Methods
 
-The `menu` class has the following static methods:
+The `Menu` class has the following static methods:
 
 #### `Menu.setApplicationMenu(menu)`
 


### PR DESCRIPTION
Changed lower case for word `menu` to upper case - `Menu`