### PR TITLE
fix: change 'string' to 'String'

### DIFF
--- a/content/en-US/docs/api/app.md
+++ b/content/en-US/docs/api/app.md
@@ -684,7 +684,7 @@ To set the locale, you'll want to use a command line switch at app startup, whic
 **Note:** On Windows, you have to call it after the `ready` events gets emitted.
 
 ### `app.getLocaleCountryCode()`
-Returns `string` - User operating system's locale two-letter [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) country code. The value is taken from native OS APIs.
+Returns `String` - User operating system's locale two-letter [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) country code. The value is taken from native OS APIs.
 
 **Note:** When unable to detect locale country code, it returns empty string.
 


### PR DESCRIPTION
Change 'string' to 'String', because that class name.

<!--
Thanks for opening a pull request!

Note: translations should not be submitted as pull requests.

See the README for info on how to participate:

https://github.com/electron/i18n#readme
-->