### PR TITLE
fix: docs/api/app.md: add parentheses

### DIFF
--- a/content/en-US/docs/api/app.md
+++ b/content/en-US/docs/api/app.md
@@ -1151,7 +1151,7 @@ This API must be called after the `ready` event is emitted.
 
 **Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
 
-### `app.showAboutPanel` _macOS_ _Linux_
+### `app.showAboutPanel()` _macOS_ _Linux_
 
 Show the app's about panel options. These options can be overridden with `app.setAboutPanelOptions(options)`.
 


### PR DESCRIPTION
Add parentheses to the end `app.showAboutPanel`, because this is method.

<!--
Thanks for opening a pull request!

Note: translations should not be submitted as pull requests.

See the README for info on how to participate:

https://github.com/electron/i18n#readme
-->