### PR TITLE
文本样式错乱修复。

### DIFF
--- a/content/zh-CN/docs/development/debugging-instructions-macos.md
+++ b/content/zh-CN/docs/development/debugging-instructions-macos.md
@@ -28,7 +28,9 @@ Relevant code files can be found in `./atom/`.
 
 ```sh
 (lldb) breakpoint set --file browser.cc --line 117
-Breakpoint 1: where = Electron Framework`atom::Browser::SetName(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 20 at browser.cc:118, address = 0x000000000015fdb4
+Breakpoint 1: where = Electron Framework`atom::Browser::SetName(
+    std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&
+)+ 20 at browser.cc:118, address = 0x000000000015fdb4
 ```
 
 然后, 启动 Electron:
@@ -43,8 +45,12 @@ Breakpoint 1: where = Electron Framework`atom::Browser::SetName(std::__1::basic_
 (lldb) run
 Process 25244 launched: '/Users/fr/Code/electron/out/Debug/Electron.app/Contents/MacOS/Electron' (x86_64)
 Process 25244 stopped
-* thread #1: tid = 0x839a4c, 0x0000000100162db4 Electron Framework`atom::Browser::SetName(this=0x0000000108b14f20, name="Electron") + 20 at browser.cc:118, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
-    frame #0: 0x0000000100162db4 Electron Framework`atom::Browser::SetName(this=0x0000000108b14f20, name="Electron") + 20 at browser.cc:118
+* thread #1: tid = 0x839a4c, 0x0000000100162db4 Electron Framework`atom::Browser::SetName(
+    this=0x0000000108b14f20, name="Electron"
+)+ 20 at browser.cc:118, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
+    frame #0: 0x0000000100162db4 Electron Framework`atom::Browser::SetName(
+        this=0x0000000108b14f20, name="Electron"
+    ) + 20 at browser.cc:118
    115  }
    116
    117  void Browser::SetName(const std::string& name) {
@@ -70,8 +76,12 @@ Process 25244 stopped
 ```sh
 (lldb) step
 Process 25244 stopped
-* thread #1: tid = 0x839a4c, 0x0000000100162dcc Electron Framework`atom::Browser::SetName(this=0x0000000108b14f20, name="Electron") + 44 at browser.cc:119, queue = 'com.apple.main-thread', stop reason = step in
-    frame #0: 0x0000000100162dcc Electron Framework`atom::Browser::SetName(this=0x0000000108b14f20, name="Electron") + 44 at browser.cc:119
+* thread #1: tid = 0x839a4c, 0x0000000100162dcc Electron Framework`atom::Browser::SetName(
+    this=0x0000000108b14f20, name="Electron"
+)+ 44 at browser.cc:119, queue = 'com.apple.main-thread', stop reason = step in
+    frame #0: 0x0000000100162dcc Electron Framework`atom::Browser::SetName(
+        this=0x0000000108b14f20, name="Electron"
+    ) + 44 at browser.cc:119
    116
    117  void Browser::SetName(const std::string& name) {
    118    name_override_ = name;


### PR DESCRIPTION
原文本样式没有换行，超出了代码背景框的范围

<!--
Thanks for opening a pull request!

Note: translations should not be submitted as pull requests.

See the README for info on how to participate:

https://github.com/electron/i18n#readme
-->