### PR TITLE
fix: change url format of fiddle transformer

### DIFF
--- a/lib/remark-fiddle-urls.js
+++ b/lib/remark-fiddle-urls.js
@@ -14,7 +14,7 @@ const fiddleUrls = () => tree => {
     const matches = node.lang.match(regex)
     if (matches) {
       // retrieve and remove url from language definition
-      const url = `electron/${electronLatestStableTag}/docs/fiddles/${matches[2]}`
+      const url = `electron/${electronLatestStableTag}/${matches[2]}`
       node.lang = matches[1] + matches[3]
 
       // save url in data-fiddle-url html attribute

--- a/lib/remark-fiddle-urls.js
+++ b/lib/remark-fiddle-urls.js
@@ -1,4 +1,5 @@
 const visit = require('unist-util-visit')
+const { electronLatestStableTag } = require('../package.json')
 
 const regex = /(javascript.*|js.*) fiddle='([^']*)'(.*)/
 
@@ -13,14 +14,8 @@ const fiddleUrls = () => tree => {
     const matches = node.lang.match(regex)
     if (matches) {
       // retrieve and remove url from language definition
-      const url = matches[2]
+      const url = `electron/${electronLatestStableTag}/docs/fiddles/${matches[2]}`
       node.lang = matches[1] + matches[3]
-
-      // validate url
-      if (!(url.startsWith('electron/') || url.startsWith('gist/'))) {
-        console.warn('Found invalid fiddle url:', url)
-        return
-      }
 
       // save url in data-fiddle-url html attribute
       node.data = node.data || {}

--- a/lib/remark-fiddle-urls.js
+++ b/lib/remark-fiddle-urls.js
@@ -17,7 +17,7 @@ const fiddleUrls = () => tree => {
       node.lang = matches[1] + matches[3]
 
       // validate url
-      if (!url.startsWith('electron-fiddle://')) {
+      if (!(url.startsWith('electron/') || url.startsWith('gist/'))) {
         console.warn('Found invalid fiddle url:', url)
         return
       }


### PR DESCRIPTION
With the new [fiddle.electronjs.org/launch](https://fiddle.electronjs.org/launch) page, validation takes place there - here the only thing left is to inject the current docs version.

ref https://github.com/electron/fiddle.electronjs.org/pull/1

cc @MarshallOfSound @zeke 