### PR TITLE
Added dev.to link to help section

### DIFF
--- a/content/en-US/website/locale.yml
+++ b/content/en-US/website/locale.yml
@@ -77,7 +77,9 @@ community:
       posting on
       <a href='https://discuss.atom.io/c/electron'>Discuss</a>,
       or visiting
-      <a href='https://stackoverflow.com/questions/tagged/electron'>Stack Overflow</a>."
+      <a href='https://stackoverflow.com/questions/tagged/electron'>Stack Overflow</a>
+      or 
+      <a href='https://dev.to/t/electron'>DEV Communtiy</a>."
     security:
       "<a href='mailto:security@electronjs.org'><b>Report security issues</b></a>
       by emailing


### PR DESCRIPTION
This change adds a useful link to the help section.

DEV's Electron tag is a place to share Electron projects, articles, and tutorials as well as start discussions and ask for feedback on electron related topics.  Developers of all skill-levels are welcome to take part.

A few additional links pertaining to dev.to

Traffic stats: https://www.similarweb.com/website/dev.to 
Twitter: https://twitter.com/thepracticaldev 
Electron tag (as included in PR): https://dev.to/t/electron

