### PR TITLE
fix: add transformer for fix builds

### DIFF
--- a/lib/remark-its-really-js.js
+++ b/lib/remark-its-really-js.js
@@ -1,0 +1,16 @@
+const visit = require('unist-util-visit')
+
+// FIXME(HashimotoYT): This doesn't should live, but for now I see one exit. 😔
+
+const regex = /^(javascript.*|js.*)/
+
+const itsReallyJS = () => tree => {
+  visit(tree, 'code', node => {
+    if (regex.test(node.lang)) {
+      node.lang = node.lang.replace(regex, 'javascript')
+    }
+  })
+  return tree
+}
+
+module.exports = itsReallyJS

--- a/script/build-module.js
+++ b/script/build-module.js
@@ -19,6 +19,7 @@ const links = require('remark-inline-links')
 const parseElectronGlossary = require('../lib/parse-electron-glossary')
 const plaintextFix = require('../lib/remark-plaintext-fix')
 const fiddleUrls = require('../lib/remark-fiddle-urls')
+const itsReallyJS = require('../lib/remark-its-really-js')
 
 const contentDir = path.join(__dirname, '../content')
 const cheerio = require('cheerio')
@@ -97,7 +98,7 @@ async function parseFile(file) {
   file.sections = await Promise.all(
     splitMd(await fixMdLinks(markdown)).map(async section => {
       const parsed = await hubdown(section.body, {
-        runBefore: [plaintextFix, fiddleUrls],
+        runBefore: [plaintextFix, fiddleUrls, itsReallyJS],
       })
       const $ = cheerio.load(parsed.content || '')
       file.title =


### PR DESCRIPTION
This Pull Request adds a transformer for fixing builds. For more infromation you can see error below:

```txt
Error: Unknown language: `javascript const electron = require('electron') const { app, BrowserWindow } = electron` is not registered
```

## How, and where it's broke everything?

This error starts after the first pull from translation, where these non-standard language string doesn't parse normally. For me this error from Crowdin side where these non-standard language strings not used every day.

## What's this PR do?

This PR adds a transformer that finds these broken strings and changes to standard ```javascript. This file doesn't should live a long time, she should be removed in some time.

## If it's not ideally what this can break?

Page layout on non-English pages. This not break fully, it's readable, but not looks ideally (very).

---

It's not an ideal solution for this but for now, I see it as a comfortable exit from a situation where documentation doesn't update properly.