### PR TITLE
build: Revert "build(deps-dev): bump husky from 4.0.7 to 4.0.9"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2394,6 +2394,12 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -2999,14 +3005,15 @@
       "dev": true
     },
     "husky": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-4.0.9.tgz",
-      "integrity": "sha512-zaH0INH9MZBH8smr6nPdzv7pjchOZPN/AKdhkuV4zut9SyF0+pUy1ZCBzhz2uPe7Cp75YzD92ewU2ytIZ0GjUQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.0.7.tgz",
+      "integrity": "sha512-ULivTOe0k+nNjZKIojoHxXjybtEycaba0EDuk1G8iNGD8wZgo8Sr3YiN8bKitXNpI1RvVKTJwRnh2GLysLbxMQ==",
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
         "ci-info": "^2.0.0",
         "cosmiconfig": "^6.0.0",
+        "get-stdin": "^7.0.0",
         "opencollective-postinstall": "^2.0.2",
         "pkg-dir": "^4.2.0",
         "please-upgrade-node": "^3.2.0",


### PR DESCRIPTION
Husky 4.0.9 broke the pre-push hook 😔

Reverts electron/i18n#1053