### PR TITLE
build: make dependabot only run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "13:00"
   open-pull-requests-limit: 99


### PR DESCRIPTION
To limit the noise for notifications, this PR changes the dependency checks from daily to weekly. There are a lot of dev deps in this repo, and they're all low-ish priority to keep up to date.