### PR TITLE
fix: path to get CrowdinFileId

### DIFF
--- a/lib/parsers/docs-parser.ts
+++ b/lib/parsers/docs-parser.ts
@@ -32,8 +32,7 @@ export async function parseFile(file: Entry, ids: Record<string, string>) {
   // build a reference to the source
   const githubUrl = `https://github.com/electron/electron/tree/master${href}.md`
 
-  // TODO: this needs to be updated once the flattening happens
-  const crowdinFileId = ids[`master_old/content/en-US${href}.md`]
+  const crowdinFileId = ids[`[electron.i18n] master/content/en-US${href}.md`]
 
   // convenience booleans for use in templates
   const isTutorial = category === 'tutorial'
@@ -112,7 +111,9 @@ export async function parseFile(file: Entry, ids: Record<string, string>) {
         // turn `../images/foo/bar.png` into `/docs/images/foo/bar.png`
         src = convertToUrlSlash(path.resolve(dirname, src))
 
-        const newSrc = [baseUrl, packageJSON.electronLatestStableTag, src].join('/')
+        const newSrc = [baseUrl, packageJSON.electronLatestStableTag, src].join(
+          '/'
+        )
 
         const parsed = URL.parse(newSrc)
         if (!parsed.path) return

--- a/test.js
+++ b/test.js
@@ -1,4 +1,0 @@
-const i18n = require('./dist/')
-
-const doc = i18n.docs['fr-FR']['/docs/api/structures/gpu-feature-status']
-doc.crowdinFileId.should.equal('128')

--- a/test/index.js
+++ b/test/index.js
@@ -258,7 +258,7 @@ describe('API Structures', () => {
 
   it('sets expected crowdinFileId', () => {
     const doc = i18n.docs['fr-FR']['/docs/api/structures/gpu-feature-status']
-    doc.crowdinFileId.should.equal('128')
+    doc.crowdinFileId.should.equal('250646')
   })
 })
 


### PR DESCRIPTION
Had to rename some branches in Crowdin's side to get the flattening structure correctly.
This PR fixes the path again and should pass once the new sync is in place.