### PR TITLE
fix: run relative link transformer on `definition` nodes as well

### DIFF
--- a/lib/transfomers/remark-relative-links.ts
+++ b/lib/transfomers/remark-relative-links.ts
@@ -23,6 +23,7 @@ export function fixRelativeLinks(doc: IDocFile) {
     visit<Href>(tree, hasRelativeUrl, (node) => {
       const dir = path.dirname(doc.href)
       switch (node.type) {
+        case 'definition':
         case 'link':
           node.url = convertToUrlSlash(
             path.resolve(dir, node.url.replace(/\.md/, ''))

--- a/test/index.js
+++ b/test/index.js
@@ -170,6 +170,15 @@ describe('API Docs', () => {
     link.attr('href').should.equal('/docs/glossary#main-process')
   })
 
+  // since we use remark-relative-links in markdown, the parsing logic
+  // for definition nodes is separate from link nodes in the AST
+  it('fixes relative definitions in docs', () => {
+    const api = i18n.docs['en-US']['/docs/tutorial/installation']
+    const $ = cheerio.load(api.html)
+    const link = $('a[href*="electron-versioning"]').first()
+    link.attr('href').should.equal('/docs/tutorial/electron-versioning')
+  })
+
   it('fixes relative images in docs', () => {
     const doc = i18n.docs['en-US']['/docs/tutorial/electron-versioning']
     const $ = cheerio.load(doc.html)


### PR DESCRIPTION
Fixes #1842 

Currently, the relative link fixer only checks for nodes of type `link`. This PR extends the fix to [`definition`](https://github.com/syntax-tree/mdast#definition) nodes so that relative links added with `remark-inline-links` work.