### PR TITLE
feat: ignore extra fiddle embed params

### DIFF
--- a/lib/transfomers/remark-fiddle-urls.ts
+++ b/lib/transfomers/remark-fiddle-urls.ts
@@ -16,7 +16,6 @@ interface IAdditionalNode extends Node {
   }
 }
 
-
 // remark transformer for 'code' blocks to
 // embed fiddle urls as html attributes
 export const fiddleUrls = () => (tree: Node) => {
@@ -29,7 +28,7 @@ export const fiddleUrls = () => (tree: Node) => {
     if (langMatch && metaMatch) {
       // Valid format for the meta is fiddle='folder|<option>|<option>' where |<option> is optional.
       // However, nothing but the folder is supported by this plugin.
-      const [folder, ..._] = metaMatch[1].split("|");
+      const [folder, ..._] = metaMatch[1].split('|')
 
       // retrieve and remove url from language definition
       const url = `electron/${electronLatestStableTag}/${folder}`

--- a/lib/transfomers/remark-fiddle-urls.ts
+++ b/lib/transfomers/remark-fiddle-urls.ts
@@ -16,6 +16,7 @@ interface IAdditionalNode extends Node {
   }
 }
 
+
 // remark transformer for 'code' blocks to
 // embed fiddle urls as html attributes
 export const fiddleUrls = () => (tree: Node) => {
@@ -26,8 +27,12 @@ export const fiddleUrls = () => (tree: Node) => {
     const metaMatch = node.meta.match(metaRegex)
 
     if (langMatch && metaMatch) {
+      // Valid format for the meta is fiddle='folder|<option>|<option>' where |<option> is optional.
+      // However, nothing but the folder is supported by this plugin.
+      const [folder, ..._] = metaMatch[1].split("|");
+
       // retrieve and remove url from language definition
-      const url = `electron/${electronLatestStableTag}/${metaMatch[1]}`
+      const url = `electron/${electronLatestStableTag}/${folder}`
 
       // save url in data-fiddle-url html attribute
       node.data = node.data || {}


### PR DESCRIPTION
The new electron docs website has support for optional parameters when embedding a fiddle. This PR just makes sure we ignore them.

See electron/electronjs.org-new/pull/36

Manually verified by adding a `|focus=main.js` to `quick-start.md`.

**Without this change**
![image](https://user-images.githubusercontent.com/556834/119059758-cc0b1780-b985-11eb-84e7-bd86d130701d.png)

**With this change**
![image](https://user-images.githubusercontent.com/556834/119059838-f3fa7b00-b985-11eb-80be-7beed663b348.png)

<!--
Thanks for opening a pull request!

Note: translations should not be submitted as pull requests.

See the README for info on how to participate:

https://github.com/electron/i18n#readme
-->

cc: @erickzhao 