### PR TITLE
fix zh-CN/electron-vs-nwjs

### DIFF
--- a/content/zh-CN/docs/development/electron-vs-nwjs.md
+++ b/content/zh-CN/docs/development/electron-vs-nwjs.md
@@ -1,8 +1,8 @@
-# Electron 和 NW.js 之间的技术差异 类似于NW.js，Electron提供了一个使用Web技术开发桌面应用程序的平台。它们都可以让开发者很便利地使用HTML、JavaScript以及Node.js进行开发。表面上，它们俩非常相似。、 然而，两个项目间依旧存在着一些本质的差异，这使得Electron是一个完全独立且不同于NW.js的项目。 1）应用程序的入口 NW.js中，应用程序的主入口是一个HTML网页。NW.js将会使用一个浏览器窗口打开给定的入口点（HTML网页）。 在Electron中，入口点是一个Javascript脚本文件。我们需要通过Javascript代码手动创建一个浏览器窗口并加载一个HTML文件，而不是直接提供一个URL的方法。当然我们也可以去监听窗口的事件来决定什么时候退出应用程序。 Electron的工作机制更像是Node.js的运行时。而且Electron的API实际上更为底层，所以我们可以使用它进行相应的浏览器测试并替代PhantomJS。 2）Node集成 在NW.js中，在Web页面中集成Node需要通过给Chromium打补丁的方式才能运行。而Electron采取了通过在集成libuv loop——不同的操作系统平台（Windows、Linux、MacOS）的消息循环来避免魔改Chromium。 3）Javascript上下文
+# Electron 和 NW.js 之间的技术差异
 
 类似于 NW.js，Electron 提供了一个使用 Web 技术开发桌面应用程序的平台。 两个平台都允许开发者使用 HTML、JavaScript 和 Node.js。 表面上，它们似乎非常相似。
 
-但是这两个项目也有本质上的区别，使得 Electron 和 NW.js 成为两个相互独立的产品。
+然而，两个项目间依旧存在着一些本质的差异，这使得 Electron 和 NW.js 成为两个相互独立的产品。
 
 ## 1) 应用程序的入口
 
@@ -40,5 +40,6 @@ NW.js 仍然提供一个支持 Windows XP 的 "传统版本"， 它没有收到�
 
 当然，我们相信 Electron 是用 Web 技术构建生产应用程序更好的平台（如 Visual Studio Code、Slack 或 Facebook Messenger）；但是，我们希望公平对待同样用 Web 技术的朋友。 如果你有 Electron 不能满足的功能需求，你可能需要尝试 NW.js。
 
+[nwjs]: https://nwjs.io/
 [electron-modules]: https://www.npmjs.com/search?q=electron
 [node-bindings]: https://github.com/electron/electron/tree/master/lib/common


### PR DESCRIPTION
There is a very long line at title, so fix it.

<img  alt="image" src="https://user-images.githubusercontent.com/1926185/132157816-d2d775fd-b66c-4b76-9bd4-b398be0dbe0c.png">
